### PR TITLE
Remove the puppet directory if it doesn't match the git repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 	test -n "$(FUNCTION)"  # $$FUNCTION
 	test -n "$(PUPPET_REPO)"  # $$PUPPET_REPO
 	test -n "$(PACKER_PROFILE)" #$$PACKER_PROFILE
+	if [[ -d "puppet/" ]] && ! git --git-dir=./puppet/.git remote get-url origin | grep --quiet $(PUPPET_REPO); then rm -rf ./puppet; fi
 	if [[ ! -d "puppet/" ]]; then git clone $(PUPPET_REPO) puppet; fi
 	cd puppet && git pull && git submodule update --init --recursive
 	packer build -var 'aws_region=$(AWS_REGION)' -var 'aws_source_ami=$(SOURCE_AMI)' -var 'project=$(PROJECT)' -var 'environment=$(ENVIRONMENT)' -var 'function=$(FUNCTION)' -var 'aws_ec2_profile=$(PACKER_PROFILE)' -var 'module_paths=$(MODULE_PATHS)' aws.json


### PR DESCRIPTION
Otherwise it could lead to issues if someone forgets to remove the `puppet` directory and tries to build images on another repo.