### PR TITLE
Set defaults for ROOT_VOLUME, cfr. 6a26213

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL := /bin/bash
 AWS_SOURCE_AMI ?= ami-7abd0209
 AWS_REGION ?= eu-west-1
+ROOT_VOLUME_SIZE ?= 8
+ROOT_VOLUME_TYPE ?= standard
 
 ifeq ($(wildcard ../modules),)
   MODULE_PATHS ?= '"puppet/modules"'

--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ Create an AMI from puppet files
 * [`FUNCTION`]: The instance function, used in facter
 * [`PUPPET_REPO`]: A git url to the puppet files
 * [`PACKER_PROFILE`]: The name of the profile to use when running packer
-* [`ROOT_VOLUME_SIZE`]: The size of the root volume default to 8
+* [`ROOT_VOLUME_SIZE`]: The size (in GiB) of the root volume, default to `8`
+* [`ROOT_VOLUME_TYPE`]: The size of the root volume, default to `standard`


### PR DESCRIPTION
Extra ROOT_VOLUME_* vars were added in commit 6a26213, but no defaults are set. This can break Packer builds where the vars aren't set explicitly.

This change provides a default value for these vars.