### PR TITLE
Install aws-sdk version for CodeDeploy compatibility

### DIFF
--- a/scripts/puppet_install.sh
+++ b/scripts/puppet_install.sh
@@ -7,6 +7,9 @@ echo " - Done"
 sudo /usr/bin/logger -t autobootstrap "installed puppet"
 echo "* installing gems"
 sudo gem install hiera-eyaml
+# aws-codedeploy-agent 1.0-1.1067 depends on aws-sdk-core ~2.6.11 and will ERROR on newer versions (~2.7).
+# We'll probably have to update again once they release the newest version with commit:
+# https://github.com/aws/aws-codedeploy-agent/commit/50db2ec9013cfe8f1a857de53c806d6c67d8d07b
 sudo gem install aws-sdk -v '~> 2.6.11'
 sudo gem install hiera-eyaml-kms
 echo " - Done"

--- a/scripts/puppet_install.sh
+++ b/scripts/puppet_install.sh
@@ -7,7 +7,7 @@ echo " - Done"
 sudo /usr/bin/logger -t autobootstrap "installed puppet"
 echo "* installing gems"
 sudo gem install hiera-eyaml
-sudo gem install aws-sdk
+sudo gem install aws-sdk -v '~> 2.6.11'
 sudo gem install hiera-eyaml-kms
 echo " - Done"
 sudo /usr/bin/logger -t autobootstrap "installed puppet gems"


### PR DESCRIPTION
The latest codedeploy version depends on `aws-sdk-core ~> 2.6.11`. Otherwise the agent will fail. Our install script didn't consider specific versions and just installs the latest, which at the time of writing is `2.7.0`.

```
2017-01-25 16:52:48 ERROR [codedeploy-agent(4049)]: Plugin codedeploy could not be loaded: Unable to activate codedeploy-commands-1.0.0, because aws-sdk-core-2.7.1 conflicts with aws-sdk-core (~> 2.6.11).
2017-01-25 16:52:48 ERROR [codedeploy-agent(4049)]: booting child: error during start or run: Gem::ConflictError - Unable to activate codedeploy-commands-1.0.0, because aws-sdk-core-2.7.1 conflicts with aws-sdk-core (~> 2.6.11) - /usr/lib/ruby/2.3.0/rubygems/specification.rb:2286:in `raise_if_conflicts
```

Tested manually on a packer-build instance.