### PR TITLE
Add deep_merge as required gem install

### DIFF
--- a/scripts/puppet_install.sh
+++ b/scripts/puppet_install.sh
@@ -32,5 +32,6 @@ sudo /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
 # https://github.com/aws/aws-codedeploy-agent/commit/50db2ec9013cfe8f1a857de53c806d6c67d8d07b
 sudo /opt/puppetlabs/puppet/bin/gem install aws-sdk -v '~> 2.6.11'
 sudo /opt/puppetlabs/puppet/bin/gem install hiera-eyaml-kms
+sudo /opt/puppetlabs/puppet/bin/gem install deep_merge
 echo " - Done"
 sudo /usr/bin/logger -t autobootstrap "installed puppet gems"


### PR DESCRIPTION
We need deep_merge if we want to have a `deeper` merge behaviour in hiera. This is needed if we define values of hashes at multiple levels in our hiera structure.