### PR TITLE
delete the ubuntu sudo conf

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -3,3 +3,5 @@ export DEBIAN_FRONTEND=noninteractive
 
 sudo apt-get -y clean
 sudo apt-get -y autoremove
+
+sudo rm /etc/sudoers.d/10-ubuntu &> /dev/null || true


### PR DESCRIPTION
delete the sudo conf for ubuntu as part of the cleanup.
will not throw an error if it doesn't exist